### PR TITLE
PerimeterTrackerSpeed, BatteryChargerTime and MotorBackwardTurn

### DIFF
--- a/RazorBoard 1.0 rev. E/Core/Inc/sram.h
+++ b/RazorBoard 1.0 rev. E/Core/Inc/sram.h
@@ -28,6 +28,8 @@ static const char VERSION[] = "Version 1.0.3";
 #define MOTORMINSPEED_ADDR				0x3A	//uint16_t
 #define CUTTERSPEED_ADDR				0x3C	//uint16_t
 #define ADC_LEVEL_ADDR					0x3E	//uint16_t
+#define PERIMETERTRACKERSPEED_ADDR		0x40	//uint16_t
+#define BATTERYCHARGETIME_ADDR			0x42	//uint16_t
 
 #define BATTERY_LOW_LIMIT_ADDR			0x64	//uint32_t
 #define BATTERY_HIGH_LIMIT_ADDR			0x68	//uint32_t
@@ -65,6 +67,9 @@ typedef struct SRAM {
 	uint16_t motorMinSpeed;
 	uint16_t cutterSpeed;
 	uint16_t adcLevel;
+	uint16_t perimeterTrackerSpeed;
+	uint16_t BatteryChargeTime;
+
 	float Battery_Low_Limit;
 	float Battery_High_Limit;
 	float Signal_Integrity_IN;

--- a/RazorBoard 1.0 rev. E/Core/Src/help.c
+++ b/RazorBoard 1.0 rev. E/Core/Src/help.c
@@ -33,6 +33,8 @@ void show_config(sram_settings settings) {
 	Serial_Console(msg);
 	sprintf(msg, "Battery Low: %.2f\r\n", settings.Battery_Low_Limit);
 	Serial_Console(msg);
+	sprintf(msg, "Battery charge time (min): %d\r\n", settings.BatteryChargeTime);
+	Serial_Console(msg);
 	sprintf(msg, "Signal IN: %.2f\r\n", settings.Signal_Integrity_IN);
 	Serial_Console(msg);
 	sprintf(msg, "Signal OUT: %.2f\r\n", settings.Signal_Integrity_OUT);
@@ -69,6 +71,8 @@ void show_config(sram_settings settings) {
 	Serial_Console(msg);
 	sprintf(msg, "Cutter Speed: %d\r\n", settings.cutterSpeed);
 	Serial_Console(msg);
+	sprintf(msg, "Perimeter Tracker Speed: %d\r\n", settings.perimeterTrackerSpeed);
+    Serial_Console(msg);
 	sprintf(msg, "Movement limit: %d\r\n", settings.move_count_limit);
 	Serial_Console(msg);
 	sprintf(msg, "Bumber limit: %d\r\n", settings.bumber_count_limit);
@@ -136,6 +140,8 @@ void help(void) {
 	Serial_Console(msg);
 	sprintf(msg, "SET BAT HIGH            - Limit when considering battery full\r\n");
 	Serial_Console(msg);
+	sprintf(msg, "SET BAT CHARGER TIME    - How many minutes to charge battery\r\n");
+	Serial_Console(msg);
 	sprintf(msg, "SET BWF OUT             - Limit for considering BWF OUT\r\n");
 	Serial_Console(msg);
 	sprintf(msg, "SET BWF IN              - Limit for considering BWF IN\r\n");
@@ -164,6 +170,7 @@ void help(void) {
 	Serial_Console(msg);
 	sprintf(msg, "TRACK PERIMETER 	- Track perimeter next time it crosses\r\n");
 	Serial_Console(msg);
+	sprintf(msg, "SET PERIMETER SPEED   - Set track perimeter speed\r\n");
 	sprintf(msg, "SET KP			- PID Controller KP for Perimeter Tracking\r\n");
 	Serial_Console(msg);
 	sprintf(msg, "SET KI			- PID Controller KI for Perimeter Tracking\r\n");

--- a/RazorBoard 1.0 rev. E/Core/Src/sram.c
+++ b/RazorBoard 1.0 rev. E/Core/Src/sram.c
@@ -137,11 +137,13 @@ sram_settings read_all_settings(void)
 	settings.magMinValue = read_sram_uint16(MAGMINVALUE_ADDR);
 	settings.motorMaxSpeed = read_sram_uint16(MOTORMAXSPEED_ADDR);
 	settings.motorMinSpeed = read_sram_uint16(MOTORMINSPEED_ADDR);
+	settings.perimeterTrackerSpeed = read_sram_uint16(PERIMETERTRACKERSPEED_ADDR);
 	settings.cutterSpeed = read_sram_uint16(CUTTERSPEED_ADDR);
 	settings.adcLevel = read_sram_uint16(ADC_LEVEL_ADDR);
 
 	settings.Battery_High_Limit = read_sram_float(BATTERY_HIGH_LIMIT_ADDR);
 	settings.Battery_Low_Limit = read_sram_float(BATTERY_LOW_LIMIT_ADDR);
+	settings.BatteryChargeTime =  read_sram_uint16(BATTERYCHARGETIME_ADDR);
 
 	settings.Signal_Integrity_IN = read_sram_float(SIGNAL_INTEGRITY_IN_ADDR);
 	settings.Signal_Integrity_OUT = read_sram_float(SIGNAL_INTEGRITY_OUT_ADDR);
@@ -190,8 +192,10 @@ void write_all_settings(sram_settings settings)
 	write_sram_uint16(settings.magMinValue, MAGMINVALUE_ADDR);
 	write_sram_uint16(settings.motorMaxSpeed, MOTORMAXSPEED_ADDR);
 	write_sram_uint16(settings.motorMinSpeed, MOTORMINSPEED_ADDR);
+	write_sram_uint16(settings.perimeterTrackerSpeed, PERIMETERTRACKERSPEED_ADDR);
 	write_sram_uint16(settings.cutterSpeed, CUTTERSPEED_ADDR);
 	write_sram_uint16(settings.adcLevel, ADC_LEVEL_ADDR);
+	write_sram_uint16(settings.BatteryChargeTime, BATTERYCHARGETIME_ADDR);
 
 
 	// uint32_t & float
@@ -247,6 +251,8 @@ void save_default_settings(void) {
 	settings.adcLevel = 1267;
 	settings.move_count_limit = 5;
 	settings.bumber_count_limit = 10;
+	settings.BatteryChargeTime = 60;
+	settings.perimeterTrackerSpeed = 2800;
 
 	write_all_settings(settings);
 


### PR DESCRIPTION
PerimeterTrackerSpeed - Configurable setting to set the speed when going home
BatteryChargerTime - Force the battery to be charged for a predefined time, even though the voltage limit has ben reached
MotorBackwardTurn - Function to use to turn during reverse for example in the undock scenario